### PR TITLE
Add support for vertical border, tab-bar, and vterm/ansi-term

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -94,8 +94,9 @@
    `(cursor ((t (:background ,gruber-darker-yellow))))
    `(default ((t ,(list :foreground gruber-darker-fg
                         :background gruber-darker-bg))))
-   `(fringe ((t ,(list :background gruber-darker-bg-1
+   `(fringe ((t ,(list :background nil
                        :foreground gruber-darker-bg+2))))
+   `(vertical-border ((t ,(list :foreground gruber-darker-bg+2))))
    `(link ((t (:foreground ,gruber-darker-niagara :underline t))))
    `(link-visited ((t (:foreground ,gruber-darker-wisteria :underline t))))
    `(match ((t (:background ,gruber-darker-bg+4))))

--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -368,6 +368,21 @@
    `(whitespace-space-before-tab ((t ,(list :background gruber-darker-brown
                                             :foreground gruber-darker-brown))))
 
+   ;; tab-bar
+   `(tab-bar ((t (:background ,gruber-darker-bg+1 :foreground ,gruber-darker-bg+4))))
+   `(tab-bar-tab ((t (:background nil :foreground ,gruber-darker-yellow :weight bold))))
+   `(tab-bar-tab-inactive ((t (:background nil))))
+
+   ;; vterm / ansi-term
+   `(term-color-black ((t (:foreground ,gruber-darker-bg+3 :background ,gruber-darker-bg+4))))
+   `(term-color-red ((t (:foreground ,gruber-darker-red-1 :background ,gruber-darker-red-1))))
+   `(term-color-green ((t (:foreground ,gruber-darker-green :background ,gruber-darker-green))))
+   `(term-color-blue ((t (:foreground ,gruber-darker-niagara :background ,gruber-darker-niagara))))
+   `(term-color-yellow ((t (:foreground ,gruber-darker-yellow :background ,gruber-darker-yellow))))
+   `(term-color-magenta ((t (:foreground ,gruber-darker-wisteria :background ,gruber-darker-wisteria))))
+   `(term-color-cyan ((t (:foreground ,gruber-darker-quartz :background ,gruber-darker-quartz))))
+   `(term-color-white ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-white))))
+
    ;;;;; company-mode
    `(company-tooltip ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg+1))))


### PR DESCRIPTION
Hey, this is my favorite theme, I'd like to suggest some additions that I've been making locally for a while now.

1. Remove the fringe background and add a face for vertical border, this will make window splits more subtle (currently it's a glowing white line which I find a bit in my face). Removing the fringe background also plays nicer with other fringe modes, e.g. git-gutter-fringe.
2. Add support for Emacs 28's new built-in tab-bar-mode. Styled similarly to the modeline.
3. Add term colors for modes line vterm or ansi-term. Currently they fall back to the standard colors and are very hard to read (especially dark blue and red).

I've used existing colors for all of the changes, so I think it fits nicely.

(This PR does not bump the package number.)