### PR TITLE
Add support for rainbow-delimeters (a.k.a rainbow-parenthesis and stuff)

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -33,9 +33,18 @@
 ;; variant of the Gruber Dark theme for BBEdit by John Gruber. Adapted
 ;; for deftheme and extended by Alexey Kutepov a.k.a. rexim.
 
-
 (deftheme gruber-darker
   "Gruber Darker color theme for Emacs 24")
+
+;; Monokai colors for rainbow-delimiters.
+(defcustom gruber-theme-yellow "#E6DB74" "Primary colors - yellow" :type 'string :group 'monokai)
+(defcustom gruber-theme-orange "#FD971F" "Primary colors - orange" :type 'string :group 'monokai)
+(defcustom gruber-theme-red "#F92672" "Primary colors - red" :type 'string :group 'monokai)
+(defcustom gruber-theme-magenta "#FD5FF0" "Primary colors - magenta" :type 'string :group 'monokai)
+(defcustom gruber-theme-blue "#66D9EF" "Primary colors - blue" :type 'string :group 'monokai)
+(defcustom gruber-theme-green "#A6E22E" "Primary colors - green" :type 'string :group 'monokai)
+(defcustom gruber-theme-cyan "#A1EFE4" "Primary colors - cyan" :type 'string :group 'monokai)
+(defcustom gruber-theme-violet "#AE81FF" "Primary colors - violet" :type 'string :group 'monokai)
 
 ;; Please, install rainbow-mode.
 ;; Colors with +x are lighter. Colors with -x are darker.
@@ -383,7 +392,21 @@
    `(term-color-cyan ((t (:foreground ,gruber-darker-quartz :background ,gruber-darker-quartz))))
    `(term-color-white ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-white))))
 
-   ;;;;; company-mode
+;;;;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,gruber-theme-violet))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,gruber-theme-blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,gruber-theme-green))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,gruber-theme-yellow))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,gruber-theme-orange))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,gruber-theme-red))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,gruber-theme-violet))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,gruber-theme-blue))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,gruber-theme-green))))
+   `(rainbow-delimiters-depth-10-face ((t (:foreground ,gruber-theme-yellow))))
+   `(rainbow-delimiters-depth-11-face ((t (:foreground ,gruber-theme-orange))))
+   `(rainbow-delimiters-depth-12-face ((t (:foreground ,gruber-theme-red))))
+
+;;;;; company-mode
    `(company-tooltip ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation-selection ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg-1))))
@@ -396,7 +419,7 @@
    `(company-preview ((t (:background ,gruber-darker-green))))
    `(company-preview-common ((t (:foreground ,gruber-darker-green :background ,gruber-darker-bg-1))))
 
-   ;;;;; Proof General
+;;;;; Proof General
    `(proof-locked-face ((t (:background ,gruber-darker-niagara-2))))
    ))
 

--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -392,7 +392,7 @@
    `(term-color-cyan ((t (:foreground ,gruber-darker-quartz :background ,gruber-darker-quartz))))
    `(term-color-white ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-white))))
 
-;;;;; rainbow-delimiters
+   ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,gruber-theme-violet))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,gruber-theme-blue))))
    `(rainbow-delimiters-depth-3-face ((t (:foreground ,gruber-theme-green))))
@@ -406,7 +406,7 @@
    `(rainbow-delimiters-depth-11-face ((t (:foreground ,gruber-theme-orange))))
    `(rainbow-delimiters-depth-12-face ((t (:foreground ,gruber-theme-red))))
 
-;;;;; company-mode
+   ;;;;; company-mode
    `(company-tooltip ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation-selection ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg-1))))
@@ -419,7 +419,7 @@
    `(company-preview ((t (:background ,gruber-darker-green))))
    `(company-preview-common ((t (:foreground ,gruber-darker-green :background ,gruber-darker-bg-1))))
 
-;;;;; Proof General
+   ;;;;; Proof General
    `(proof-locked-face ((t (:background ,gruber-darker-niagara-2))))
    ))
 


### PR DESCRIPTION
I really like your theme but I've noticed there's no support for [rainbow-delimeters](https://github.com/Fanael/rainbow-delimiters), which is an extension which I really enjoy using when dealing with Lisps.

I basically borrowed the code used by the [naysayer theme](https://github.com/nickav/naysayer-theme.el) and I though it fitted really nicely with the colorscheme of `gruber-darker`.

Feel free to deny the pull and/or ask me to change the colors to ones which you think are better.