### PR TITLE
Add support for orderless

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -383,7 +383,7 @@
    `(term-color-cyan ((t (:foreground ,gruber-darker-quartz :background ,gruber-darker-quartz))))
    `(term-color-white ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-white))))
 
-   ;;;;; company-mode
+   ;; company-mode
    `(company-tooltip ((t (:foreground ,gruber-darker-fg :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg+1))))
    `(company-tooltip-annotation-selection ((t (:foreground ,gruber-darker-brown :background ,gruber-darker-bg-1))))
@@ -396,8 +396,14 @@
    `(company-preview ((t (:background ,gruber-darker-green))))
    `(company-preview-common ((t (:foreground ,gruber-darker-green :background ,gruber-darker-bg-1))))
 
-   ;;;;; Proof General
+   ;; Proof General
    `(proof-locked-face ((t (:background ,gruber-darker-niagara-2))))
+
+   ;; Orderless
+   `(orderless-match-face-0 ((t (:foreground ,gruber-darker-yellow))))
+   `(orderless-match-face-1 ((t (:foreground ,gruber-darker-green))))
+   `(orderless-match-face-2 ((t (:foreground ,gruber-darker-brown))))
+   `(orderless-match-face-3 ((t (:foreground ,gruber-darker-quartz))))
    ))
 
 ;;;###autoload


### PR DESCRIPTION
I use [orderless](https://github.com/oantolin/orderless) for filtering/narrowing in the minibuffer, and it introduced its own faces to highlight 4 tiers of matches. The default with `gruber-darker`  would be so that it doesn't highlight anything, which is kinda undesirable.

I used four different colors to highlight the matches. This is how it looks:

![2023-08-10-214754_1532x199_scrot](https://github.com/rexim/gruber-darker-theme/assets/5188977/3bff7649-e5d9-4fcb-b88a-ff84eca20557)
