### PR TITLE
Add completion annotation face

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -127,6 +127,9 @@
                                            :weight 'bold
                                            :inherit 'unspecified))))
 
+   ;; Completion
+   `(completions-annotations ((t (:inherit 'shadow))))
+
    ;; Custom
    `(custom-state ((t (:foreground ,gruber-darker-green))))
 


### PR DESCRIPTION
I use `marginalia` to display additional information for completions, and default face was unreadable. Marginalia uses `marginalia-documentation`, which inherits `completions-annotations`, which inherits `(italic shadow)`, which looks like this:

![20231024_13h09m15s_grim](https://github.com/rexim/gruber-darker-theme/assets/30533306/c877f3b6-ac8c-495e-81f2-02e9440c78c2)

By setting `completions-annotations` to inherit only `shadow` looks cleaner and more readable while potentially working for more plugins than just for my original use case.

![20231024_13h09m40s_grim](https://github.com/rexim/gruber-darker-theme/assets/30533306/ec26ae90-d43e-47ad-ad43-1f4b9c0fab56)
