### PR TITLE
Fix weird source code block display in org-mode

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -310,6 +310,7 @@
 
    ;; Org Mode
    `(org-agenda-structure ((t (:foreground ,gruber-darker-niagara))))
+   `(org-block ((t (:background ,gruber-darker-bg :foreground ,gruber-darker-fg))))
    `(org-column ((t (:background ,gruber-darker-bg-1))))
    `(org-column-title ((t (:background ,gruber-darker-bg-1 :underline t :weight bold))))
    `(org-done ((t (:foreground ,gruber-darker-green))))


### PR DESCRIPTION

<img width="541" alt="Screenshot 2025-04-13 at 11 39 43 AM" src="https://github.com/user-attachments/assets/cd25a84a-fa35-4452-90ad-16b99475e890" />


This is changing to: 

<img width="558" alt="Screenshot 2025-04-13 at 11 40 29 AM" src="https://github.com/user-attachments/assets/248ff001-721b-43df-aeda-7ce53fee9df6" />
