### PR TITLE
Fix inverted mode-line

### DIFF
--- a/gruber-darker-theme.el
+++ b/gruber-darker-theme.el
@@ -300,8 +300,6 @@
    ;; Mode Line
    `(mode-line ((t ,(list :background gruber-darker-bg+1
                           :foreground gruber-darker-white))))
-   `(mode-line-buffer-id ((t ,(list :background gruber-darker-bg+1
-                                    :foreground gruber-darker-white))))
    `(mode-line-inactive ((t ,(list :background gruber-darker-bg+1
                                    :foreground gruber-darker-quartz))))
 


### PR DESCRIPTION
Makes sure that the buffer name inverts when inverting the mode-line with `(invert-face 'mode-line)`. Previously the mode line would invert everywhere except the buffer name.
